### PR TITLE
finish partinfo to and from dict

### DIFF
--- a/stepcvt/project.py
+++ b/stepcvt/project.py
@@ -37,6 +37,14 @@ class CADSource:
 class TaskInfo:
     """Base class for all part-specific task information"""
 
+    @classmethod
+    def gettype(cls, type_name):
+        """Return one of the subtypes given by the name"""
+        for t in cls.__subclasses__():
+            if t.__name__ == type_name:
+                return t
+        raise TypeError(f"{type_name} is not a valid TaskInfo type")
+
 
 class STLConversionInfo(TaskInfo):
     rotation: None
@@ -102,7 +110,7 @@ class PartInfo:
     """Container for all part-specific task information"""
 
     def __init__(self, part_id: str = "", info: list = None):
-        self.part_id = ""
+        self.part_id = part_id
         self.info = [] if info is None else info
 
     @classmethod
@@ -113,15 +121,16 @@ class PartInfo:
         part_id = dict["part_id"]
         info: [STLConversionInfo] = []
 
-        info_dict_list = dict["info"]
+        info_dict_list: [TaskInfo] = dict["info"]
         for info_dict in info_dict_list:
-            info.append(STLConversionInfo.from_dict(info_dict))
+            info_type: type[TaskInfo] = TaskInfo.gettype(info_dict["type"])
+            info.append(info_type.from_dict(info_dict))
 
-        x = cls()
-        x.part_id = part_id
-        x.info = info
-
-        return x
+        return cls(part_id, info)
 
     def to_dict(self):
-        return {"part_id": self.part_id, "info": [obj.to_dict() for obj in self.info]}
+        return {
+            "type": "PartInfo",
+            "part_id": self.part_id, 
+            "info": [obj.to_dict() for obj in self.info]
+        }

--- a/stepcvt/project.py
+++ b/stepcvt/project.py
@@ -131,6 +131,6 @@ class PartInfo:
     def to_dict(self):
         return {
             "type": "PartInfo",
-            "part_id": self.part_id, 
-            "info": [obj.to_dict() for obj in self.info]
+            "part_id": self.part_id,
+            "info": [obj.to_dict() for obj in self.info],
         }

--- a/tests/test_part_info.py
+++ b/tests/test_part_info.py
@@ -1,5 +1,29 @@
-from stepcvt.project import PartInfo, STLConversionInfo, TextInfo
+from stepcvt.project import PartInfo, STLConversionInfo, TextInfo, SlicerSettingsInfo
 
+pinfo = {
+    "type": "PartInfo",
+    "part_id": "some.step.file.identifier.or.name",
+    "info": [
+        {
+            "type": "STLConversionInfo",
+            "rotation": [0, 30, 0],
+            "linearTolerance": 0.1,
+            "angularTolerance": 0.2,
+        },
+        {
+            "type": "TextInfo",
+            "text": "Part must be printed using clear filament."
+        },
+        {
+            "type": "SlicerSettingsInfo",
+            "slicer": "Cura",
+            "settings": {
+                "layerHeight": "0.2mm",
+                "infillDensity": 0.4
+            }
+        }
+    ],
+}
 
 def test_PartInfo_to_dict():
     x = PartInfo(part_id="some.part.id")
@@ -10,32 +34,19 @@ def test_PartInfo_to_dict():
 
 
 def test_PartInfo_from_dict():
-    pinfo = {
-        "type": "PartInfo",
-        "part_id": "some.step.file.identifier.or.name",
-        "info": [
-            {
-                "type": "STLConversionInfo",
-                "rotation": [0, 30, 0],
-                "linearTolerance": 0.1,
-                "angularTolerance": 0.2,
-            },
-            {"type": "TextInfo", "text": "Part must be printed using clear filament."},
-        ],
-    }
-
     pi = PartInfo.from_dict(pinfo)
     assert isinstance(pi, PartInfo)
 
     assert pi.part_id == "some.step.file.identifier.or.name"
 
     assert isinstance(pi.info, list)
-    assert len(pi.info) == 2
+    assert len(pi.info) == 3
 
     # check that each dictionary is resolved to its correct type.
     # this should be done in from_dict by using the 'type' in each dictionary.
     assert isinstance(pi.info[0], STLConversionInfo)
     assert isinstance(pi.info[1], TextInfo)
+    assert isinstance(pi.info[2], SlicerSettingsInfo)
 
     si = pi.info[0]
     assert si.rotation == [0, 30, 0]
@@ -43,4 +54,8 @@ def test_PartInfo_from_dict():
     assert si.angularTolerance == 0.2
 
     ti = pi.info[1]
-    assert pi.text == pinfo["info"][1]["text"]
+    assert ti.text == pinfo["info"][1]["text"]
+    
+    sli = pi.info[2]
+    assert sli.slicer == pinfo["info"][2]["slicer"]
+    assert sli.settings == pinfo["info"][2]["settings"]

--- a/tests/test_part_info.py
+++ b/tests/test_part_info.py
@@ -10,20 +10,15 @@ pinfo = {
             "linearTolerance": 0.1,
             "angularTolerance": 0.2,
         },
-        {
-            "type": "TextInfo",
-            "text": "Part must be printed using clear filament."
-        },
+        {"type": "TextInfo", "text": "Part must be printed using clear filament."},
         {
             "type": "SlicerSettingsInfo",
             "slicer": "Cura",
-            "settings": {
-                "layerHeight": "0.2mm",
-                "infillDensity": 0.4
-            }
-        }
+            "settings": {"layerHeight": "0.2mm", "infillDensity": 0.4},
+        },
     ],
 }
+
 
 def test_PartInfo_to_dict():
     x = PartInfo(part_id="some.part.id")
@@ -55,7 +50,7 @@ def test_PartInfo_from_dict():
 
     ti = pi.info[1]
     assert ti.text == pinfo["info"][1]["text"]
-    
+
     sli = pi.info[2]
     assert sli.slicer == pinfo["info"][2]["slicer"]
     assert sli.settings == pinfo["info"][2]["settings"]


### PR DESCRIPTION
Resolves issue #9.

project.py:
 - Added a gettype method in TaskInfo class to simplify dict serialization code.
 - PartInfo constructor was not using its parameter part_id. Not sure if this is a conscious choice or a typo. Fixed it anyway.
 - Minor bugs.
 
test_part_info.py:
 - Expanded test_PartInfo_from_dict to include other TaskInfo class such as SlicerSettingsInfo.
 - Moved pinfo into global scope, so it can be reused in test_PartInfo_to_dict. 
 - Some TaskInfo serialization do not seem to be working correctly so did not expand test_PartInfo_to_dict to test for those.